### PR TITLE
Updated package name and moved to Hiera data

### DIFF
--- a/data/RedHat_6.9.yaml
+++ b/data/RedHat_6.9.yaml
@@ -1,0 +1,1 @@
+access_insights_client::package_name: redhat-access-insights

--- a/data/RedHat_7.4.yaml
+++ b/data/RedHat_7.4.yaml
@@ -1,0 +1,1 @@
+access_insights_client::package_name: redhat-access-insights

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,1 @@
+access_insights_client::package_name: insights-client 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,2 @@
+access_insights_client::package_ensure: present
 access_insights_client::package_name: insights-client 

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "Operating System Release"
+    path: "%{facts.os.family}_%{facts.operatingsystemrelease}.yaml"
+  - name: "common"
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class access_insights_client(
     $auto_config = 'True',
     $authmethod = undef,
     $username = undef,
+    String $package_ensure,
     String $package_name,
     $password = undef,
     $base_url = undef,
@@ -58,7 +59,7 @@ class access_insights_client(
     $upload_schedule = undef,
 ){
     package { $package_name:
-      ensure   => present,
+      ensure   => $package_ensure,
     }
 
     file {'/etc/redhat-access-insights/redhat-access-insights.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,25 +64,25 @@ class access_insights_client(
     file {'/etc/redhat-access-insights/redhat-access-insights.conf':
       ensure  => file,
       content => template('access_insights_client/redhat-access-insights.conf.erb'),
-      require => Package['redhat-access-insights'],
+      require => Package[$package_name],
     }
 
     case $upload_schedule {
         daily: { file { '/etc/cron.daily/redhat-access-insights':
             ensure  => 'link',
             target  => '/etc/redhat-access-insights/redhat-access-insights.cron',
-            require => Package['redhat-access-insights'],
+            require => Package[$package_name],
         }
         }
         weekly: { file { '/etc/cron.weekly/redhat-access-insights':
             ensure  => 'link',
             target  => '/etc/redhat-access-insights/redhat-access-insights.cron',
-            require => Package['redhat-access-insights'],
+            require => Package[$package_name],
         }}
         default: { file { '/etc/cron.daily/redhat-access-insights':
             ensure  => 'link',
             target  => '/etc/redhat-access-insights/redhat-access-insights.cron',
-            require => Package['redhat-access-insights'],
+            require => Package[$package_name],
         }}
     }
     if ($upload_schedule == 'weekly') {
@@ -101,6 +101,6 @@ class access_insights_client(
     exec { '/usr/bin/redhat-access-insights --register':
         creates => '/etc/redhat-access-insights/.registered',
         unless  => '/usr/bin/test -f /etc/redhat-access-insights/.unregistered',
-        require => Package['redhat-access-insights']
+        require => Package[$package_name]
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class access_insights_client(
     $auto_config = 'True',
     $authmethod = undef,
     $username = undef,
+    String $package_name,
     $password = undef,
     $base_url = undef,
     $proxy = undef,
@@ -56,8 +57,8 @@ class access_insights_client(
     $obfuscate_hostname = undef,
     $upload_schedule = undef,
 ){
-    package {'redhat-access-insights':
-      ensure   => latest,
+    package { $package_name:
+      ensure   => present,
     }
 
     file {'/etc/redhat-access-insights/redhat-access-insights.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,8 +58,6 @@ class access_insights_client(
 ){
     package {'redhat-access-insights':
       ensure   => latest,
-      provider => yum,
-      source   => 'redhat-access-insights',
     }
 
     file {'/etc/redhat-access-insights/redhat-access-insights.conf':


### PR DESCRIPTION
In recent RHEL releases, the name of the insights package has changed.
To handle this name change between RHEL versions, module level Hiera data was added.